### PR TITLE
Remove 1 unnecessary stubbing in GitHubSCMSourceTest.testShouldRetrieveNullEvent

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -919,10 +919,6 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase {
     @Issue("JENKINS-65071")
     public void testShouldRetrieveNullEvent() throws Exception {
         SCMHeadObserver mockSCMHeadObserver = Mockito.mock(SCMHeadObserver.class);
-        Mockito.when(mockSCMHeadObserver.getIncludes())
-                .thenReturn(
-                        Collections.singleton(new GitHubTagSCMHead("non-existent-tag", System.currentTimeMillis())));
-
         assertTrue(this.source.shouldRetrieve(mockSCMHeadObserver, null, GitHubTagSCMHead.class));
         assertTrue(this.source.shouldRetrieve(mockSCMHeadObserver, null, PullRequestSCMHead.class));
         assertTrue(this.source.shouldRetrieve(mockSCMHeadObserver, null, BranchSCMHead.class));


### PR DESCRIPTION
# Description

A brief summary describing the changes in this pull request. 

In our analysis of the project, we observed that the test `GitHubSCMSourceTest.testShouldRetrieveNullEvent` contains 1 unnecessary stubbing. Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). We propose below a solution to remove the unnecessary stubbing.

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

